### PR TITLE
Add Travis-CI config to build aarch64 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
         # them here for now.  They'll get picked up by the multibuild stuff
         # running in multibuild/common_utils.sh.
         #
-        - TEST_DEPENDS="pytest mock cython nmslib pyemd testfixtures Morfessor==2.0.2a4 python-Levenshtein>=0.10.2 scikit-learn visdom>=0.1.8,!=0.1.8.7 pyemd"
+        - TEST_DEPENDS="pytest mock cython nmslib pyemd testfixtures Morfessor==2.0.2a4 python-Levenshtein>=0.10.2 scikit-learn visdom>=0.1.8,!=0.1.8.7 pyemd pillow==8.0.1"
 
 language: python
 os: linux
@@ -41,6 +41,44 @@ jobs:
       - PLAT=x86_64
       - SKIP_NETWORK_TESTS=1
 
+  - os: linux
+    arch: arm64-graviton2
+    dist: focal
+    virt: vm
+    group: edge
+    env:
+      - BUILD_DEPENDS="numpy==1.19.2 scipy==1.5.3"
+      - MB_PYTHON_VERSION=3.6
+      - PLAT=aarch64
+      - MB_ML_VER=2014
+      - SKIP_NETWORK_TESTS=1
+      - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+
+  - os: linux
+    arch: arm64-graviton2
+    dist: focal
+    virt: vm
+    group: edge
+    env:
+      - BUILD_DEPENDS="numpy==1.19.2 scipy==1.5.3"
+      - MB_PYTHON_VERSION=3.7
+      - PLAT=aarch64
+      - MB_ML_VER=2014
+      - SKIP_NETWORK_TESTS=1
+      - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+
+  - os: linux
+    arch: arm64-graviton2
+    dist: focal
+    virt: vm
+    group: edge
+    env:
+      - BUILD_DEPENDS="numpy==1.19.2 scipy==1.5.3"
+      - MB_PYTHON_VERSION=3.8
+      - PLAT=aarch64
+      - MB_ML_VER=2014
+      - SKIP_NETWORK_TESTS=1
+      - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
 
   # MacOS
   - os: osx


### PR DESCRIPTION
Travis-CI allows to build aarch64 wheels. The config added uses Graviton2 instances to build and test the wheels. Travis added Graviton2 support recently. Please see: https://blog.travis-ci.com/2020-09-11-arm-on-aws

Build log: https://travis-ci.com/github/janaknat/gensim-wheels/builds/212374355

The test failures in the arm64 build are the same as the amd64 build.